### PR TITLE
Fix Router namespace casing

### DIFF
--- a/Bootstrap/Router.php
+++ b/Bootstrap/Router.php
@@ -150,7 +150,7 @@ class Router
         $urlArray = $this->parseUrl($_SERVER['REQUEST_URI']);
 
         // Set the name space, class and action according to the url.
-        $nameSpace = isset($urlArray[0]) ? strtolower($urlArray[0]) : DEFAULT_MODULE;
+        $nameSpace = isset($urlArray[0]) ? ucwords(strtolower($urlArray[0])) : DEFAULT_MODULE;
         $class = isset($urlArray[1]) ? ucwords(strtolower($urlArray[1])) : 'Index';
         $request['action'] = isset($urlArray[2]) ? strtolower($urlArray[2]) . 'Action' : 'indexAction';
 


### PR DESCRIPTION
## Summary
Fixes the incorrect casing of the namespace variable in the Router class. The variable's value comes from the url and was not being properly capitalised to match the casing of the respective folder.

## Steps to Test
1. Observe the url is resolved correctly on case sensitive file systems (like Linux.)

