### PR TITLE
Fix production error reporting.

### DIFF
--- a/Bootstrap/Bootstrapper.php
+++ b/Bootstrap/Bootstrapper.php
@@ -112,7 +112,7 @@ class Bootstrapper
     private function setEnvironment(): void
     {
         // If development environment is on, display errors to the user.
-        if (DEVELOPMENT_ENVIRONMENT) {
+        if (DEVELOPMENT_ENVIRONMENT == false) {
             error_reporting(E_ALL);
             ini_set('display_errors', 'On');
             return;


### PR DESCRIPTION
## Summary
Fixes errors being displayed despite DEVELOPMENT_ENVIRONMENT being set to false.

## Steps to Test
1. Assert errors are not displayed to the user when DEVELOPMENT_ENVIRONMENT is set to false in the .env file.